### PR TITLE
Update cameraPathAnimation.js

### DIFF
--- a/examples/js/animation/cameraPathAnimation.js
+++ b/examples/js/animation/cameraPathAnimation.js
@@ -179,7 +179,7 @@ xeogl.CameraPathAnimation = class xeoglCameraPathAnimation extends xeogl.Compone
                 this._t += this._playingRate * f;
 
                 const numFrames = this.cameraPath.frames.length;
-                if (numFrames === 0 || (this._playingDir < 0 && this._t <= 0) || (this._playingDir > 0 && this._t >= this.cameraPath.frames[numFrames - 1].t)) {
+                if (numFrames === 0 || (this._playingDir < 0 && this._t <= 0) || (this._playingDir > 0 && this._t >= 1.0)) {
                     this.state = xeogl.CameraPathAnimation.SCRUBBING;
                     this._t = this.cameraPath.frames[numFrames - 1].t;
                     return;


### PR DESCRIPTION
`this._t` will be in a range of 0.0 to 1.0 
`this.cameraPath.frames[numFrames - 1].t` provides a giving frame index as of the example, so when `this.cameraPath.frames` contains of 7 frames the `CameraPathAnimation.PLAYING` status will last until `this._t` adds up to at least 6, which in return will prevent for example `cameraControl` to function properly